### PR TITLE
fix: #7 only check for dependencies

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -17,3 +17,18 @@
         max-size: "100m"
   roles:
     - geerlingguy.docker
+
+- name: Install required packages
+  hosts: all
+  tasks:
+    - name: Required packages
+      ansible.builtin.package:
+        name: "{{ ['python3-setuptools', 'python3-pip'] + (['openssh-client'] if ansible_distribution == 'Ubuntu' else ['openssh-clients']) }}"
+      become: true
+      become_user: root
+
+    - name: Required pip packages
+      ansible.builtin.pip:
+        name: ["docker"]
+      become: true
+      become_user: root

--- a/tasks/dependency.yml
+++ b/tasks/dependency.yml
@@ -1,12 +1,10 @@
 ---
-- name: Required packages
-  ansible.builtin.package:
-    name: "{{ ['python3-setuptools', 'python3-pip'] + (['openssh-client'] if ansible_distribution == 'Ubuntu' else ['openssh-clients']) }}"
-  become: true
-  become_user: root
-
-- name: Required pip packages
-  ansible.builtin.pip:
-    name: ["docker"]
-  become: true
-  become_user: root
+- name: Check for required packages
+  ansible.builtin.shell: >
+    pip3 || echo "pip3 missing";
+    ssh -G localhost || echo "openssh-client missing";
+    python3 -c 'import setuptools' || echo "setuptools python library missing";
+    python3 -c 'import docker' || echo "docker python library missing";
+  register: required_packages
+  changed_when: false
+  failed_when: "'missing' in required_packages.stdout"


### PR DESCRIPTION
removes the need for 'sudo' when running docker containers